### PR TITLE
🚀 Draft post for 'Show HN' on Hacker News

### DIFF
--- a/.darwin/show_HN.md
+++ b/.darwin/show_HN.md
@@ -1,0 +1,28 @@
+# Show HN: FastAPI - High Performance, Easy to Learn, Ready for Production
+
+Hey Hacker News community! I'm thrilled to introduce FastAPI, a modern, fast (high-performance) web framework for building APIs with Python 3.8+ based on standard Python type hints. It's designed to be easy to use, intuitive, and thanks to Pydantic and Starlette, incredibly fast.
+
+## What Makes FastAPI Stand Out?
+
+- **High Performance**: Comparable to NodeJS and Go. It's one of the fastest Python frameworks available.
+- **Developer Friendly**: Increases development speed by 200% to 300%, reduces bugs by about 40%.
+- **Intuitive**: Excellent editor support. Completion everywhere. Spend less time debugging.
+- **Easy to Learn**: Spend less time reading docs.
+- **Robust**: Production-ready code with automatic interactive documentation.
+- **Standards-based**: Fully compatible with OpenAPI and JSON Schema.
+
+## Why Did I Build FastAPI?
+
+I wanted to create a framework that combines the best of all worlds: high performance, developer friendliness, and standards compliance. The journey wasn't easy, but seeing FastAPI being used by companies like Microsoft, Uber, and Netflix, and receiving positive feedback from the developer community, has been incredibly rewarding.
+
+## Try It Out
+
+I invite you to try FastAPI for your next project. Check out the [documentation](https://fastapi.tiangolo.com) and explore the interactive API docs. I'm looking forward to your feedback and how you use FastAPI in your projects!
+
+## Engage with Us
+
+Your feedback is invaluable. Feel free to share your thoughts, questions, or feedback in the comments below. Let's make FastAPI even better, together.
+
+---
+
+FastAPI has been a labor of love, and I'm excited to see how it helps you build amazing applications. Let's revolutionize the way we develop APIs with Python!


### PR DESCRIPTION
The draft post for 'Show HN' on Hacker News has been successfully created and saved. You can find it at `.darwin/show_HN.md` in your project directory.