### PR TITLE
🚀 Draft post for 'Show HN' on Hacker News

### DIFF
--- a/.darwin/show_HN.md
+++ b/.darwin/show_HN.md
@@ -1,0 +1,20 @@
+# Show HN: FastAPI - High Performance, Easy to Learn, Fast to Code
+
+FastAPI is revolutionizing the way we build APIs with Python. It's a modern, fast (high-performance) web framework that leverages standard Python type hints to ensure high-speed development and fewer bugs. Here's why you should check it out:
+
+- **High Performance**: Comparable to NodeJS and Go, thanks to Starlette and Pydantic.
+- **Rapid Development**: Increase development speed by 200% to 300%, reducing human errors by about 40%.
+- **Intuitive**: Excellent editor support, completion everywhere, and less time debugging.
+- **Easy to Learn**: Spend less time reading docs and more time building great applications.
+- **Robust**: Production-ready code with automatic interactive documentation.
+- **Standards-based**: Fully compatible with OpenAPI and JSON Schema.
+
+From Microsoft to Uber, Netflix, and beyond, FastAPI is being adopted by developers and companies worldwide for its ease of use, scalability, and performance. Whether you're building a small project or a large-scale application, FastAPI has you covered.
+
+Check out the [documentation](https://fastapi.tiangolo.com) and [GitHub repository](https://github.com/tiangolo/fastapi) to get started. Join the growing community of developers making API development faster and more efficient with FastAPI.
+
+Your feedback and contributions are welcome! Let's build something amazing together.
+
+---
+
+*Engage with us in the comments below. We're excited to hear about your experiences with FastAPI and answer any questions you might have.*


### PR DESCRIPTION
The draft post for 'Show HN' on Hacker News has been successfully created and saved. You can find it at `.darwin/show_HN.md` in the project directory.