### PR TITLE
🚀 Draft post for 'Show HN'

### DIFF
--- a/.darwin/show_HN.md
+++ b/.darwin/show_HN.md
@@ -1,0 +1,27 @@
+# Show HN: FastAPI - High Performance, Easy to Learn, Ready for Production
+
+FastAPI is revolutionizing the way we build web APIs with Python. It's a modern, fast (high-performance) framework that makes it quick and easy to build APIs. Thanks to its reliance on standard Python type hints, FastAPI provides automatic request validation, serialization, and documentation. It's designed to be easy to use, while also enabling high performance.
+
+## Why FastAPI?
+
+- **High Performance**: Comparable to NodeJS and Go, thanks to Starlette and Pydantic.
+- **Rapid Development**: Increase development speed by 200% to 300%.
+- **Fewer Bugs**: Reduce human (developer) induced errors by about 40%.
+- **Intuitive**: Great editor support. Completion everywhere. Spend less time debugging.
+- **Easy to Learn**: Spend less time reading docs and more time building your project.
+- **Robust**: Get production-ready code. With automatic interactive documentation.
+- **Standards-based**: Fully compatible with OpenAPI and JSON Schema.
+
+## What's Unique?
+
+FastAPI stands out not just for its speed and ease of use, but for its comprehensive automatic interactive API documentation, support for asynchronous request handling, and its strong emphasis on type safety and validation.
+
+## Join Us
+
+Whether you're building a small project or a large-scale enterprise application, FastAPI has the tools and features you need. Check out our GitHub repository and join the growing community of developers who are choosing FastAPI for their web projects.
+
+**GitHub**: [https://github.com/tiangolo/fastapi](https://github.com/tiangolo/fastapi)
+
+**Documentation**: [https://fastapi.tiangolo.com](https://fastapi.tiangolo.com)
+
+We're excited to see what you build with FastAPI!


### PR DESCRIPTION
The draft post for 'Show HN' on Hacker News has been successfully created and saved. You can find it at the path `.darwin/show_HN.md` in the project directory.