### PR TITLE
Generate a hackernews post

### DIFF
--- a/.darwin/show_HN.md
+++ b/.darwin/show_HN.md
@@ -1,0 +1,15 @@
+# Show HN: FastAPI - High Performance, Easy to Learn, Fast to Code, Ready for Production
+
+FastAPI is revolutionizing the way we build APIs with Python. It's a modern, fast (high-performance) web framework that leverages standard Python type hints to bring you speed, ease of use, and fewer bugs. Here's why you should check it out:
+
+- **High Performance**: Comparable to NodeJS and Go, thanks to Starlette and Pydantic.
+- **Rapid Development**: Increase your development speed by 200% to 300%.
+- **Fewer Bugs**: Reduce human (developer) induced errors by about 40%.
+- **Intuitive**: Excellent editor support and completion everywhere means less time debugging.
+- **Easy to Learn**: Spend less time reading docs and more time building great stuff.
+- **Robust**: Get production-ready code with automatic interactive documentation.
+- **Standards-based**: Fully compatible with OpenAPI and JSON Schema.
+
+FastAPI is being used by giants like Microsoft, Uber, and Netflix to power their services. Whether you're building a small project or a large-scale application, FastAPI can help you do it better and faster. Check out the [documentation](https://fastapi.tiangolo.com) and [source code](https://github.com/tiangolo/fastapi) to get started.
+
+I'm excited to share this with the Hacker News community and look forward to your feedback and questions!


### PR DESCRIPTION
The Hacker News post draft has been successfully created and saved. You can find it at the path: `.darwin/show_HN.md`.